### PR TITLE
Wrap all strings in quotes, not just in collections

### DIFF
--- a/src/main/kotlin/com/tylerthrailkill/helpers/prettyprint/PrettyPrint.kt
+++ b/src/main/kotlin/com/tylerthrailkill/helpers/prettyprint/PrettyPrint.kt
@@ -97,7 +97,9 @@ private fun recurse(
                             writeLine(wordWrap(str, newPad))
                             write("$newPad\"\"\"")
                         } else {
+                            write("\"")
                             write(str)
+                            write("\"")
                         }
                     }
                     else -> write(fieldValue)

--- a/src/test/kotlin/com/tylerthrailkill/helpers/prettyprint/CycleDetectionTest.kt
+++ b/src/test/kotlin/com/tylerthrailkill/helpers/prettyprint/CycleDetectionTest.kt
@@ -42,15 +42,15 @@ object CycleDetectionTest : Spek({
                 NestedLargeObject(
                   nestedSmallObject = NestedSmallObject(
                     smallObject = SmallObject(
-                      field1 = a string in small object
+                      field1 = "a string in small object"
                       field2 = 777
                     )
                   )
                   smallObject = SmallObject(
-                    field1 = a string in small object
+                    field1 = "a string in small object"
                     field2 = 777
                   )
-                  testString = test string, please don't break
+                  testString = "test string, please don't break"
                   bigObject = null
                 )
                 """

--- a/src/test/kotlin/com/tylerthrailkill/helpers/prettyprint/MapTest.kt
+++ b/src/test/kotlin/com/tylerthrailkill/helpers/prettyprint/MapTest.kt
@@ -43,7 +43,7 @@ object MapTest : Spek({
                 ) mapsTo """
                 {
                   "key1" -> SmallObject(
-                    field1 = field
+                    field1 = "field"
                     field2 = 1
                   )
                 }
@@ -57,7 +57,7 @@ object MapTest : Spek({
                 ) mapsTo """
                 {
                   SmallObject(
-                    field1 = field
+                    field1 = "field"
                     field2 = 1
                   ) -> "value1"
                 }
@@ -72,11 +72,11 @@ object MapTest : Spek({
                 ) mapsTo """
                 {
                   "key1" -> SmallObject(
-                    field1 = field
+                    field1 = "field"
                     field2 = 1
                   ),
                   "key2" -> SmallObject(
-                    field1 = field2
+                    field1 = "field2"
                     field2 = 2
                   )
                 }
@@ -146,7 +146,7 @@ object MapTest : Spek({
                 ) mapsTo """
                 {
                   null -> SmallObject(
-                    field1 = field
+                    field1 = "field"
                     field2 = 1
                   )
                 }
@@ -196,7 +196,7 @@ object MapTest : Spek({
                 ) mapsTo """
                 {
                   null -> SmallObject(
-                    field1 = field
+                    field1 = "field"
                     field2 = 1
                   ),
                   "key2" -> null

--- a/src/test/kotlin/com/tylerthrailkill/helpers/prettyprint/MassiveObjectTest.kt
+++ b/src/test/kotlin/com/tylerthrailkill/helpers/prettyprint/MassiveObjectTest.kt
@@ -99,7 +99,7 @@ object MassiveObjectTest : Spek({
                 )
             ) mapsTo """
 MassiveObject(
-  astring = a string
+  astring = "a string"
   listOfObject = [
                    AValueObject(
                      uuid = b2558c12-d4d3-4abd-94e4-8600902f1edf
@@ -107,83 +107,83 @@ MassiveObject(
                      emailAddresses = [
                                         EmailAddress(
                                           serialVersionUUID = 1
-                                          emailAddress = a@b.com
+                                          emailAddress = "a@b.com"
                                         ),
                                         EmailAddress(
                                           serialVersionUUID = 1
-                                          emailAddress = 🎃@zack.is
+                                          emailAddress = "🎃@zack.is"
                                         ),
                                         EmailAddress(
                                           serialVersionUUID = 1
-                                          emailAddress = ñoñó1234@server.com
+                                          emailAddress = "ñoñó1234@server.com"
                                         ),
                                         EmailAddress(
                                           serialVersionUUID = 1
-                                          emailAddress = δοκιμή@παράδειγμα.δοκιμή
+                                          emailAddress = "δοκιμή@παράδειγμα.δοκιμή"
                                         ),
                                         EmailAddress(
                                           serialVersionUUID = 1
-                                          emailAddress = 我買@屋企.香港
+                                          emailAddress = "我買@屋企.香港"
                                         ),
                                         EmailAddress(
                                           serialVersionUUID = 1
-                                          emailAddress = 二ノ宮@黒川.日本
+                                          emailAddress = "二ノ宮@黒川.日本"
                                         ),
                                         EmailAddress(
                                           serialVersionUUID = 1
-                                          emailAddress = чебурашка@ящик-с-апельсинами.рф
+                                          emailAddress = "чебурашка@ящик-с-апельсинами.рф"
                                         ),
                                         EmailAddress(
                                           serialVersionUUID = 1
-                                          emailAddress = संपर्क@डाटामेल.भारत
+                                          emailAddress = "संपर्क@डाटामेल.भारत"
                                         ),
                                         EmailAddress(
                                           serialVersionUUID = 1
-                                          emailAddress = simple@example.com
+                                          emailAddress = "simple@example.com"
                                         ),
                                         EmailAddress(
                                           serialVersionUUID = 1
-                                          emailAddress = very.common@example.com
+                                          emailAddress = "very.common@example.com"
                                         ),
                                         EmailAddress(
                                           serialVersionUUID = 1
-                                          emailAddress = disposable.style.email.with+symbol@example.com
+                                          emailAddress = "disposable.style.email.with+symbol@example.com"
                                         ),
                                         EmailAddress(
                                           serialVersionUUID = 1
-                                          emailAddress = other.email-with-hyphen@example.com
+                                          emailAddress = "other.email-with-hyphen@example.com"
                                         ),
                                         EmailAddress(
                                           serialVersionUUID = 1
-                                          emailAddress = fully-qualified-domain@example.com
+                                          emailAddress = "fully-qualified-domain@example.com"
                                         ),
                                         EmailAddress(
                                           serialVersionUUID = 1
-                                          emailAddress = user.name+tag+sorting@example.com
+                                          emailAddress = "user.name+tag+sorting@example.com"
                                         ),
                                         EmailAddress(
                                           serialVersionUUID = 1
-                                          emailAddress = x@example.com
+                                          emailAddress = "x@example.com"
                                         ),
                                         EmailAddress(
                                           serialVersionUUID = 1
-                                          emailAddress = example-indeed@strange-example.com
+                                          emailAddress = "example-indeed@strange-example.com"
                                         ),
                                         EmailAddress(
                                           serialVersionUUID = 1
-                                          emailAddress = admin@mailserver1
+                                          emailAddress = "admin@mailserver1"
                                         ),
                                         EmailAddress(
                                           serialVersionUUID = 1
-                                          emailAddress = example@s.example
+                                          emailAddress = "example@s.example"
                                         ),
                                         EmailAddress(
                                           serialVersionUUID = 1
-                                          emailAddress = " "@example.org
+                                          emailAddress = "" "@example.org"
                                         ),
                                         EmailAddress(
                                           serialVersionUUID = 1
-                                          emailAddress = "john..doe"@example.org
+                                          emailAddress = ""john..doe"@example.org"
                                         )
                                       ]
                      nestedObjectsListToMap = [
@@ -191,39 +191,39 @@ MassiveObject(
                                                   "a" -> NestedLargeObject(
                                                     nestedSmallObject = NestedSmallObject(
                                                       smallObject = SmallObject(
-                                                        field1 = a string in small object
+                                                        field1 = "a string in small object"
                                                         field2 = 777
                                                       )
                                                     )
                                                     smallObject = SmallObject(
-                                                      field1 = a string in small object
+                                                      field1 = "a string in small object"
                                                       field2 = 777
                                                     )
-                                                    testString = test string, please don't break
+                                                    testString = "test string, please don't break"
                                                     bigObject = NestedLargeObject(
                                                       nestedSmallObject = NestedSmallObject(
                                                         smallObject = SmallObject(
-                                                          field1 = a string in small object
+                                                          field1 = "a string in small object"
                                                           field2 = 777
                                                         )
                                                       )
                                                       smallObject = SmallObject(
-                                                        field1 = a string in small object
+                                                        field1 = "a string in small object"
                                                         field2 = 777
                                                       )
-                                                      testString = test string, please don't break
+                                                      testString = "test string, please don't break"
                                                       bigObject = NestedLargeObject(
                                                         nestedSmallObject = NestedSmallObject(
                                                           smallObject = SmallObject(
-                                                            field1 = a string in small object
+                                                            field1 = "a string in small object"
                                                             field2 = 777
                                                           )
                                                         )
                                                         smallObject = SmallObject(
-                                                          field1 = a string in small object
+                                                          field1 = "a string in small object"
                                                           field2 = 777
                                                         )
-                                                        testString = test string, please don't break
+                                                        testString = "test string, please don't break"
                                                         bigObject = null
                                                       )
                                                     )
@@ -231,39 +231,39 @@ MassiveObject(
                                                   "b" -> NestedLargeObject(
                                                     nestedSmallObject = NestedSmallObject(
                                                       smallObject = SmallObject(
-                                                        field1 = a string in small object
+                                                        field1 = "a string in small object"
                                                         field2 = 777
                                                       )
                                                     )
                                                     smallObject = SmallObject(
-                                                      field1 = a string in small object
+                                                      field1 = "a string in small object"
                                                       field2 = 777
                                                     )
-                                                    testString = test string, please don't break
+                                                    testString = "test string, please don't break"
                                                     bigObject = NestedLargeObject(
                                                       nestedSmallObject = NestedSmallObject(
                                                         smallObject = SmallObject(
-                                                          field1 = a string in small object
+                                                          field1 = "a string in small object"
                                                           field2 = 777
                                                         )
                                                       )
                                                       smallObject = SmallObject(
-                                                        field1 = a string in small object
+                                                        field1 = "a string in small object"
                                                         field2 = 777
                                                       )
-                                                      testString = test string, please don't break
+                                                      testString = "test string, please don't break"
                                                       bigObject = NestedLargeObject(
                                                         nestedSmallObject = NestedSmallObject(
                                                           smallObject = SmallObject(
-                                                            field1 = a string in small object
+                                                            field1 = "a string in small object"
                                                             field2 = 777
                                                           )
                                                         )
                                                         smallObject = SmallObject(
-                                                          field1 = a string in small object
+                                                          field1 = "a string in small object"
                                                           field2 = 777
                                                         )
-                                                        testString = test string, please don't break
+                                                        testString = "test string, please don't break"
                                                         bigObject = null
                                                       )
                                                     )
@@ -271,39 +271,39 @@ MassiveObject(
                                                   "c" -> NestedLargeObject(
                                                     nestedSmallObject = NestedSmallObject(
                                                       smallObject = SmallObject(
-                                                        field1 = a string in small object
+                                                        field1 = "a string in small object"
                                                         field2 = 777
                                                       )
                                                     )
                                                     smallObject = SmallObject(
-                                                      field1 = a string in small object
+                                                      field1 = "a string in small object"
                                                       field2 = 777
                                                     )
-                                                    testString = test string, please don't break
+                                                    testString = "test string, please don't break"
                                                     bigObject = NestedLargeObject(
                                                       nestedSmallObject = NestedSmallObject(
                                                         smallObject = SmallObject(
-                                                          field1 = a string in small object
+                                                          field1 = "a string in small object"
                                                           field2 = 777
                                                         )
                                                       )
                                                       smallObject = SmallObject(
-                                                        field1 = a string in small object
+                                                        field1 = "a string in small object"
                                                         field2 = 777
                                                       )
-                                                      testString = test string, please don't break
+                                                      testString = "test string, please don't break"
                                                       bigObject = NestedLargeObject(
                                                         nestedSmallObject = NestedSmallObject(
                                                           smallObject = SmallObject(
-                                                            field1 = a string in small object
+                                                            field1 = "a string in small object"
                                                             field2 = 777
                                                           )
                                                         )
                                                         smallObject = SmallObject(
-                                                          field1 = a string in small object
+                                                          field1 = "a string in small object"
                                                           field2 = 777
                                                         )
-                                                        testString = test string, please don't break
+                                                        testString = "test string, please don't break"
                                                         bigObject = null
                                                       )
                                                     )
@@ -313,39 +313,39 @@ MassiveObject(
                                                   "d" -> NestedLargeObject(
                                                     nestedSmallObject = NestedSmallObject(
                                                       smallObject = SmallObject(
-                                                        field1 = a string in small object
+                                                        field1 = "a string in small object"
                                                         field2 = 777
                                                       )
                                                     )
                                                     smallObject = SmallObject(
-                                                      field1 = a string in small object
+                                                      field1 = "a string in small object"
                                                       field2 = 777
                                                     )
-                                                    testString = test string, please don't break
+                                                    testString = "test string, please don't break"
                                                     bigObject = NestedLargeObject(
                                                       nestedSmallObject = NestedSmallObject(
                                                         smallObject = SmallObject(
-                                                          field1 = a string in small object
+                                                          field1 = "a string in small object"
                                                           field2 = 777
                                                         )
                                                       )
                                                       smallObject = SmallObject(
-                                                        field1 = a string in small object
+                                                        field1 = "a string in small object"
                                                         field2 = 777
                                                       )
-                                                      testString = test string, please don't break
+                                                      testString = "test string, please don't break"
                                                       bigObject = NestedLargeObject(
                                                         nestedSmallObject = NestedSmallObject(
                                                           smallObject = SmallObject(
-                                                            field1 = a string in small object
+                                                            field1 = "a string in small object"
                                                             field2 = 777
                                                           )
                                                         )
                                                         smallObject = SmallObject(
-                                                          field1 = a string in small object
+                                                          field1 = "a string in small object"
                                                           field2 = 777
                                                         )
-                                                        testString = test string, please don't break
+                                                        testString = "test string, please don't break"
                                                         bigObject = null
                                                       )
                                                     )
@@ -353,39 +353,39 @@ MassiveObject(
                                                   "e" -> NestedLargeObject(
                                                     nestedSmallObject = NestedSmallObject(
                                                       smallObject = SmallObject(
-                                                        field1 = a string in small object
+                                                        field1 = "a string in small object"
                                                         field2 = 777
                                                       )
                                                     )
                                                     smallObject = SmallObject(
-                                                      field1 = a string in small object
+                                                      field1 = "a string in small object"
                                                       field2 = 777
                                                     )
-                                                    testString = test string, please don't break
+                                                    testString = "test string, please don't break"
                                                     bigObject = NestedLargeObject(
                                                       nestedSmallObject = NestedSmallObject(
                                                         smallObject = SmallObject(
-                                                          field1 = a string in small object
+                                                          field1 = "a string in small object"
                                                           field2 = 777
                                                         )
                                                       )
                                                       smallObject = SmallObject(
-                                                        field1 = a string in small object
+                                                        field1 = "a string in small object"
                                                         field2 = 777
                                                       )
-                                                      testString = test string, please don't break
+                                                      testString = "test string, please don't break"
                                                       bigObject = NestedLargeObject(
                                                         nestedSmallObject = NestedSmallObject(
                                                           smallObject = SmallObject(
-                                                            field1 = a string in small object
+                                                            field1 = "a string in small object"
                                                             field2 = 777
                                                           )
                                                         )
                                                         smallObject = SmallObject(
-                                                          field1 = a string in small object
+                                                          field1 = "a string in small object"
                                                           field2 = 777
                                                         )
-                                                        testString = test string, please don't break
+                                                        testString = "test string, please don't break"
                                                         bigObject = null
                                                       )
                                                     )
@@ -393,39 +393,39 @@ MassiveObject(
                                                   "f" -> NestedLargeObject(
                                                     nestedSmallObject = NestedSmallObject(
                                                       smallObject = SmallObject(
-                                                        field1 = a string in small object
+                                                        field1 = "a string in small object"
                                                         field2 = 777
                                                       )
                                                     )
                                                     smallObject = SmallObject(
-                                                      field1 = a string in small object
+                                                      field1 = "a string in small object"
                                                       field2 = 777
                                                     )
-                                                    testString = test string, please don't break
+                                                    testString = "test string, please don't break"
                                                     bigObject = NestedLargeObject(
                                                       nestedSmallObject = NestedSmallObject(
                                                         smallObject = SmallObject(
-                                                          field1 = a string in small object
+                                                          field1 = "a string in small object"
                                                           field2 = 777
                                                         )
                                                       )
                                                       smallObject = SmallObject(
-                                                        field1 = a string in small object
+                                                        field1 = "a string in small object"
                                                         field2 = 777
                                                       )
-                                                      testString = test string, please don't break
+                                                      testString = "test string, please don't break"
                                                       bigObject = NestedLargeObject(
                                                         nestedSmallObject = NestedSmallObject(
                                                           smallObject = SmallObject(
-                                                            field1 = a string in small object
+                                                            field1 = "a string in small object"
                                                             field2 = 777
                                                           )
                                                         )
                                                         smallObject = SmallObject(
-                                                          field1 = a string in small object
+                                                          field1 = "a string in small object"
                                                           field2 = 777
                                                         )
-                                                        testString = test string, please don't break
+                                                        testString = "test string, please don't break"
                                                         bigObject = null
                                                       )
                                                     )
@@ -435,39 +435,39 @@ MassiveObject(
                                                   "g" -> NestedLargeObject(
                                                     nestedSmallObject = NestedSmallObject(
                                                       smallObject = SmallObject(
-                                                        field1 = a string in small object
+                                                        field1 = "a string in small object"
                                                         field2 = 777
                                                       )
                                                     )
                                                     smallObject = SmallObject(
-                                                      field1 = a string in small object
+                                                      field1 = "a string in small object"
                                                       field2 = 777
                                                     )
-                                                    testString = test string, please don't break
+                                                    testString = "test string, please don't break"
                                                     bigObject = NestedLargeObject(
                                                       nestedSmallObject = NestedSmallObject(
                                                         smallObject = SmallObject(
-                                                          field1 = a string in small object
+                                                          field1 = "a string in small object"
                                                           field2 = 777
                                                         )
                                                       )
                                                       smallObject = SmallObject(
-                                                        field1 = a string in small object
+                                                        field1 = "a string in small object"
                                                         field2 = 777
                                                       )
-                                                      testString = test string, please don't break
+                                                      testString = "test string, please don't break"
                                                       bigObject = NestedLargeObject(
                                                         nestedSmallObject = NestedSmallObject(
                                                           smallObject = SmallObject(
-                                                            field1 = a string in small object
+                                                            field1 = "a string in small object"
                                                             field2 = 777
                                                           )
                                                         )
                                                         smallObject = SmallObject(
-                                                          field1 = a string in small object
+                                                          field1 = "a string in small object"
                                                           field2 = 777
                                                         )
-                                                        testString = test string, please don't break
+                                                        testString = "test string, please don't break"
                                                         bigObject = null
                                                       )
                                                     )
@@ -475,39 +475,39 @@ MassiveObject(
                                                   "h" -> NestedLargeObject(
                                                     nestedSmallObject = NestedSmallObject(
                                                       smallObject = SmallObject(
-                                                        field1 = a string in small object
+                                                        field1 = "a string in small object"
                                                         field2 = 777
                                                       )
                                                     )
                                                     smallObject = SmallObject(
-                                                      field1 = a string in small object
+                                                      field1 = "a string in small object"
                                                       field2 = 777
                                                     )
-                                                    testString = test string, please don't break
+                                                    testString = "test string, please don't break"
                                                     bigObject = NestedLargeObject(
                                                       nestedSmallObject = NestedSmallObject(
                                                         smallObject = SmallObject(
-                                                          field1 = a string in small object
+                                                          field1 = "a string in small object"
                                                           field2 = 777
                                                         )
                                                       )
                                                       smallObject = SmallObject(
-                                                        field1 = a string in small object
+                                                        field1 = "a string in small object"
                                                         field2 = 777
                                                       )
-                                                      testString = test string, please don't break
+                                                      testString = "test string, please don't break"
                                                       bigObject = NestedLargeObject(
                                                         nestedSmallObject = NestedSmallObject(
                                                           smallObject = SmallObject(
-                                                            field1 = a string in small object
+                                                            field1 = "a string in small object"
                                                             field2 = 777
                                                           )
                                                         )
                                                         smallObject = SmallObject(
-                                                          field1 = a string in small object
+                                                          field1 = "a string in small object"
                                                           field2 = 777
                                                         )
-                                                        testString = test string, please don't break
+                                                        testString = "test string, please don't break"
                                                         bigObject = null
                                                       )
                                                     )
@@ -515,39 +515,39 @@ MassiveObject(
                                                   "i" -> NestedLargeObject(
                                                     nestedSmallObject = NestedSmallObject(
                                                       smallObject = SmallObject(
-                                                        field1 = a string in small object
+                                                        field1 = "a string in small object"
                                                         field2 = 777
                                                       )
                                                     )
                                                     smallObject = SmallObject(
-                                                      field1 = a string in small object
+                                                      field1 = "a string in small object"
                                                       field2 = 777
                                                     )
-                                                    testString = test string, please don't break
+                                                    testString = "test string, please don't break"
                                                     bigObject = NestedLargeObject(
                                                       nestedSmallObject = NestedSmallObject(
                                                         smallObject = SmallObject(
-                                                          field1 = a string in small object
+                                                          field1 = "a string in small object"
                                                           field2 = 777
                                                         )
                                                       )
                                                       smallObject = SmallObject(
-                                                        field1 = a string in small object
+                                                        field1 = "a string in small object"
                                                         field2 = 777
                                                       )
-                                                      testString = test string, please don't break
+                                                      testString = "test string, please don't break"
                                                       bigObject = NestedLargeObject(
                                                         nestedSmallObject = NestedSmallObject(
                                                           smallObject = SmallObject(
-                                                            field1 = a string in small object
+                                                            field1 = "a string in small object"
                                                             field2 = 777
                                                           )
                                                         )
                                                         smallObject = SmallObject(
-                                                          field1 = a string in small object
+                                                          field1 = "a string in small object"
                                                           field2 = 777
                                                         )
-                                                        testString = test string, please don't break
+                                                        testString = "test string, please don't break"
                                                         bigObject = null
                                                       )
                                                     )
@@ -559,39 +559,39 @@ MassiveObject(
                                                   NestedLargeObject(
                                                     nestedSmallObject = NestedSmallObject(
                                                       smallObject = SmallObject(
-                                                        field1 = a string in small object
+                                                        field1 = "a string in small object"
                                                         field2 = 777
                                                       )
                                                     )
                                                     smallObject = SmallObject(
-                                                      field1 = a string in small object
+                                                      field1 = "a string in small object"
                                                       field2 = 777
                                                     )
-                                                    testString = test string, please don't break
+                                                    testString = "test string, please don't break"
                                                     bigObject = NestedLargeObject(
                                                       nestedSmallObject = NestedSmallObject(
                                                         smallObject = SmallObject(
-                                                          field1 = a string in small object
+                                                          field1 = "a string in small object"
                                                           field2 = 777
                                                         )
                                                       )
                                                       smallObject = SmallObject(
-                                                        field1 = a string in small object
+                                                        field1 = "a string in small object"
                                                         field2 = 777
                                                       )
-                                                      testString = test string, please don't break
+                                                      testString = "test string, please don't break"
                                                       bigObject = NestedLargeObject(
                                                         nestedSmallObject = NestedSmallObject(
                                                           smallObject = SmallObject(
-                                                            field1 = a string in small object
+                                                            field1 = "a string in small object"
                                                             field2 = 777
                                                           )
                                                         )
                                                         smallObject = SmallObject(
-                                                          field1 = a string in small object
+                                                          field1 = "a string in small object"
                                                           field2 = 777
                                                         )
-                                                        testString = test string, please don't break
+                                                        testString = "test string, please don't break"
                                                         bigObject = null
                                                       )
                                                     )
@@ -599,39 +599,39 @@ MassiveObject(
                                                   NestedLargeObject(
                                                     nestedSmallObject = NestedSmallObject(
                                                       smallObject = SmallObject(
-                                                        field1 = a string in small object
+                                                        field1 = "a string in small object"
                                                         field2 = 777
                                                       )
                                                     )
                                                     smallObject = SmallObject(
-                                                      field1 = a string in small object
+                                                      field1 = "a string in small object"
                                                       field2 = 777
                                                     )
-                                                    testString = test string, please don't break
+                                                    testString = "test string, please don't break"
                                                     bigObject = NestedLargeObject(
                                                       nestedSmallObject = NestedSmallObject(
                                                         smallObject = SmallObject(
-                                                          field1 = a string in small object
+                                                          field1 = "a string in small object"
                                                           field2 = 777
                                                         )
                                                       )
                                                       smallObject = SmallObject(
-                                                        field1 = a string in small object
+                                                        field1 = "a string in small object"
                                                         field2 = 777
                                                       )
-                                                      testString = test string, please don't break
+                                                      testString = "test string, please don't break"
                                                       bigObject = NestedLargeObject(
                                                         nestedSmallObject = NestedSmallObject(
                                                           smallObject = SmallObject(
-                                                            field1 = a string in small object
+                                                            field1 = "a string in small object"
                                                             field2 = 777
                                                           )
                                                         )
                                                         smallObject = SmallObject(
-                                                          field1 = a string in small object
+                                                          field1 = "a string in small object"
                                                           field2 = 777
                                                         )
-                                                        testString = test string, please don't break
+                                                        testString = "test string, please don't break"
                                                         bigObject = null
                                                       )
                                                     )
@@ -639,39 +639,39 @@ MassiveObject(
                                                   NestedLargeObject(
                                                     nestedSmallObject = NestedSmallObject(
                                                       smallObject = SmallObject(
-                                                        field1 = a string in small object
+                                                        field1 = "a string in small object"
                                                         field2 = 777
                                                       )
                                                     )
                                                     smallObject = SmallObject(
-                                                      field1 = a string in small object
+                                                      field1 = "a string in small object"
                                                       field2 = 777
                                                     )
-                                                    testString = test string, please don't break
+                                                    testString = "test string, please don't break"
                                                     bigObject = NestedLargeObject(
                                                       nestedSmallObject = NestedSmallObject(
                                                         smallObject = SmallObject(
-                                                          field1 = a string in small object
+                                                          field1 = "a string in small object"
                                                           field2 = 777
                                                         )
                                                       )
                                                       smallObject = SmallObject(
-                                                        field1 = a string in small object
+                                                        field1 = "a string in small object"
                                                         field2 = 777
                                                       )
-                                                      testString = test string, please don't break
+                                                      testString = "test string, please don't break"
                                                       bigObject = NestedLargeObject(
                                                         nestedSmallObject = NestedSmallObject(
                                                           smallObject = SmallObject(
-                                                            field1 = a string in small object
+                                                            field1 = "a string in small object"
                                                             field2 = 777
                                                           )
                                                         )
                                                         smallObject = SmallObject(
-                                                          field1 = a string in small object
+                                                          field1 = "a string in small object"
                                                           field2 = 777
                                                         )
-                                                        testString = test string, please don't break
+                                                        testString = "test string, please don't break"
                                                         bigObject = null
                                                       )
                                                     )
@@ -681,39 +681,39 @@ MassiveObject(
                                                   NestedLargeObject(
                                                     nestedSmallObject = NestedSmallObject(
                                                       smallObject = SmallObject(
-                                                        field1 = a string in small object
+                                                        field1 = "a string in small object"
                                                         field2 = 777
                                                       )
                                                     )
                                                     smallObject = SmallObject(
-                                                      field1 = a string in small object
+                                                      field1 = "a string in small object"
                                                       field2 = 777
                                                     )
-                                                    testString = test string, please don't break
+                                                    testString = "test string, please don't break"
                                                     bigObject = NestedLargeObject(
                                                       nestedSmallObject = NestedSmallObject(
                                                         smallObject = SmallObject(
-                                                          field1 = a string in small object
+                                                          field1 = "a string in small object"
                                                           field2 = 777
                                                         )
                                                       )
                                                       smallObject = SmallObject(
-                                                        field1 = a string in small object
+                                                        field1 = "a string in small object"
                                                         field2 = 777
                                                       )
-                                                      testString = test string, please don't break
+                                                      testString = "test string, please don't break"
                                                       bigObject = NestedLargeObject(
                                                         nestedSmallObject = NestedSmallObject(
                                                           smallObject = SmallObject(
-                                                            field1 = a string in small object
+                                                            field1 = "a string in small object"
                                                             field2 = 777
                                                           )
                                                         )
                                                         smallObject = SmallObject(
-                                                          field1 = a string in small object
+                                                          field1 = "a string in small object"
                                                           field2 = 777
                                                         )
-                                                        testString = test string, please don't break
+                                                        testString = "test string, please don't break"
                                                         bigObject = null
                                                       )
                                                     )
@@ -721,39 +721,39 @@ MassiveObject(
                                                   NestedLargeObject(
                                                     nestedSmallObject = NestedSmallObject(
                                                       smallObject = SmallObject(
-                                                        field1 = a string in small object
+                                                        field1 = "a string in small object"
                                                         field2 = 777
                                                       )
                                                     )
                                                     smallObject = SmallObject(
-                                                      field1 = a string in small object
+                                                      field1 = "a string in small object"
                                                       field2 = 777
                                                     )
-                                                    testString = test string, please don't break
+                                                    testString = "test string, please don't break"
                                                     bigObject = NestedLargeObject(
                                                       nestedSmallObject = NestedSmallObject(
                                                         smallObject = SmallObject(
-                                                          field1 = a string in small object
+                                                          field1 = "a string in small object"
                                                           field2 = 777
                                                         )
                                                       )
                                                       smallObject = SmallObject(
-                                                        field1 = a string in small object
+                                                        field1 = "a string in small object"
                                                         field2 = 777
                                                       )
-                                                      testString = test string, please don't break
+                                                      testString = "test string, please don't break"
                                                       bigObject = NestedLargeObject(
                                                         nestedSmallObject = NestedSmallObject(
                                                           smallObject = SmallObject(
-                                                            field1 = a string in small object
+                                                            field1 = "a string in small object"
                                                             field2 = 777
                                                           )
                                                         )
                                                         smallObject = SmallObject(
-                                                          field1 = a string in small object
+                                                          field1 = "a string in small object"
                                                           field2 = 777
                                                         )
-                                                        testString = test string, please don't break
+                                                        testString = "test string, please don't break"
                                                         bigObject = null
                                                       )
                                                     )
@@ -761,39 +761,39 @@ MassiveObject(
                                                   NestedLargeObject(
                                                     nestedSmallObject = NestedSmallObject(
                                                       smallObject = SmallObject(
-                                                        field1 = a string in small object
+                                                        field1 = "a string in small object"
                                                         field2 = 777
                                                       )
                                                     )
                                                     smallObject = SmallObject(
-                                                      field1 = a string in small object
+                                                      field1 = "a string in small object"
                                                       field2 = 777
                                                     )
-                                                    testString = test string, please don't break
+                                                    testString = "test string, please don't break"
                                                     bigObject = NestedLargeObject(
                                                       nestedSmallObject = NestedSmallObject(
                                                         smallObject = SmallObject(
-                                                          field1 = a string in small object
+                                                          field1 = "a string in small object"
                                                           field2 = 777
                                                         )
                                                       )
                                                       smallObject = SmallObject(
-                                                        field1 = a string in small object
+                                                        field1 = "a string in small object"
                                                         field2 = 777
                                                       )
-                                                      testString = test string, please don't break
+                                                      testString = "test string, please don't break"
                                                       bigObject = NestedLargeObject(
                                                         nestedSmallObject = NestedSmallObject(
                                                           smallObject = SmallObject(
-                                                            field1 = a string in small object
+                                                            field1 = "a string in small object"
                                                             field2 = 777
                                                           )
                                                         )
                                                         smallObject = SmallObject(
-                                                          field1 = a string in small object
+                                                          field1 = "a string in small object"
                                                           field2 = 777
                                                         )
-                                                        testString = test string, please don't break
+                                                        testString = "test string, please don't break"
                                                         bigObject = null
                                                       )
                                                     )
@@ -803,39 +803,39 @@ MassiveObject(
                                                   NestedLargeObject(
                                                     nestedSmallObject = NestedSmallObject(
                                                       smallObject = SmallObject(
-                                                        field1 = a string in small object
+                                                        field1 = "a string in small object"
                                                         field2 = 777
                                                       )
                                                     )
                                                     smallObject = SmallObject(
-                                                      field1 = a string in small object
+                                                      field1 = "a string in small object"
                                                       field2 = 777
                                                     )
-                                                    testString = test string, please don't break
+                                                    testString = "test string, please don't break"
                                                     bigObject = NestedLargeObject(
                                                       nestedSmallObject = NestedSmallObject(
                                                         smallObject = SmallObject(
-                                                          field1 = a string in small object
+                                                          field1 = "a string in small object"
                                                           field2 = 777
                                                         )
                                                       )
                                                       smallObject = SmallObject(
-                                                        field1 = a string in small object
+                                                        field1 = "a string in small object"
                                                         field2 = 777
                                                       )
-                                                      testString = test string, please don't break
+                                                      testString = "test string, please don't break"
                                                       bigObject = NestedLargeObject(
                                                         nestedSmallObject = NestedSmallObject(
                                                           smallObject = SmallObject(
-                                                            field1 = a string in small object
+                                                            field1 = "a string in small object"
                                                             field2 = 777
                                                           )
                                                         )
                                                         smallObject = SmallObject(
-                                                          field1 = a string in small object
+                                                          field1 = "a string in small object"
                                                           field2 = 777
                                                         )
-                                                        testString = test string, please don't break
+                                                        testString = "test string, please don't break"
                                                         bigObject = null
                                                       )
                                                     )
@@ -843,39 +843,39 @@ MassiveObject(
                                                   NestedLargeObject(
                                                     nestedSmallObject = NestedSmallObject(
                                                       smallObject = SmallObject(
-                                                        field1 = a string in small object
+                                                        field1 = "a string in small object"
                                                         field2 = 777
                                                       )
                                                     )
                                                     smallObject = SmallObject(
-                                                      field1 = a string in small object
+                                                      field1 = "a string in small object"
                                                       field2 = 777
                                                     )
-                                                    testString = test string, please don't break
+                                                    testString = "test string, please don't break"
                                                     bigObject = NestedLargeObject(
                                                       nestedSmallObject = NestedSmallObject(
                                                         smallObject = SmallObject(
-                                                          field1 = a string in small object
+                                                          field1 = "a string in small object"
                                                           field2 = 777
                                                         )
                                                       )
                                                       smallObject = SmallObject(
-                                                        field1 = a string in small object
+                                                        field1 = "a string in small object"
                                                         field2 = 777
                                                       )
-                                                      testString = test string, please don't break
+                                                      testString = "test string, please don't break"
                                                       bigObject = NestedLargeObject(
                                                         nestedSmallObject = NestedSmallObject(
                                                           smallObject = SmallObject(
-                                                            field1 = a string in small object
+                                                            field1 = "a string in small object"
                                                             field2 = 777
                                                           )
                                                         )
                                                         smallObject = SmallObject(
-                                                          field1 = a string in small object
+                                                          field1 = "a string in small object"
                                                           field2 = 777
                                                         )
-                                                        testString = test string, please don't break
+                                                        testString = "test string, please don't break"
                                                         bigObject = null
                                                       )
                                                     )
@@ -883,39 +883,39 @@ MassiveObject(
                                                   NestedLargeObject(
                                                     nestedSmallObject = NestedSmallObject(
                                                       smallObject = SmallObject(
-                                                        field1 = a string in small object
+                                                        field1 = "a string in small object"
                                                         field2 = 777
                                                       )
                                                     )
                                                     smallObject = SmallObject(
-                                                      field1 = a string in small object
+                                                      field1 = "a string in small object"
                                                       field2 = 777
                                                     )
-                                                    testString = test string, please don't break
+                                                    testString = "test string, please don't break"
                                                     bigObject = NestedLargeObject(
                                                       nestedSmallObject = NestedSmallObject(
                                                         smallObject = SmallObject(
-                                                          field1 = a string in small object
+                                                          field1 = "a string in small object"
                                                           field2 = 777
                                                         )
                                                       )
                                                       smallObject = SmallObject(
-                                                        field1 = a string in small object
+                                                        field1 = "a string in small object"
                                                         field2 = 777
                                                       )
-                                                      testString = test string, please don't break
+                                                      testString = "test string, please don't break"
                                                       bigObject = NestedLargeObject(
                                                         nestedSmallObject = NestedSmallObject(
                                                           smallObject = SmallObject(
-                                                            field1 = a string in small object
+                                                            field1 = "a string in small object"
                                                             field2 = 777
                                                           )
                                                         )
                                                         smallObject = SmallObject(
-                                                          field1 = a string in small object
+                                                          field1 = "a string in small object"
                                                           field2 = 777
                                                         )
-                                                        testString = test string, please don't break
+                                                        testString = "test string, please don't break"
                                                         bigObject = null
                                                       )
                                                     )

--- a/src/test/kotlin/com/tylerthrailkill/helpers/prettyprint/NestedObjectTest.kt
+++ b/src/test/kotlin/com/tylerthrailkill/helpers/prettyprint/NestedObjectTest.kt
@@ -12,7 +12,7 @@ object NestedObjectTest : Spek({
             prettyPrint(NestedSmallObject(SmallObject("a", 1))) mapsTo """
                 NestedSmallObject(
                   smallObject = SmallObject(
-                    field1 = a
+                    field1 = "a"
                     field2 = 1
                   )
                 )
@@ -38,27 +38,27 @@ object NestedObjectTest : Spek({
                 NestedLargeObject(
                   nestedSmallObject = NestedSmallObject(
                     smallObject = SmallObject(
-                      field1 = smallObjectField1
+                      field1 = "smallObjectField1"
                       field2 = 777
                     )
                   )
                   smallObject = SmallObject(
-                    field1 = a field in top level nested large object
+                    field1 = "a field in top level nested large object"
                     field2 = 17
                   )
-                  testString = a test string in NestedLargeObject
+                  testString = "a test string in NestedLargeObject"
                   bigObject = NestedLargeObject(
                     nestedSmallObject = NestedSmallObject(
                       smallObject = SmallObject(
-                        field1 = inner small object field 1
+                        field1 = "inner small object field 1"
                         field2 = 888
                       )
                     )
                     smallObject = SmallObject(
-                      field1 = field 1 in nested small
+                      field1 = "field 1 in nested small"
                       field2 = 12
                     )
-                    testString = a test string in NestedLargeObject inner
+                    testString = "a test string in NestedLargeObject inner"
                     bigObject = null
                   )
                 )
@@ -120,7 +120,7 @@ object NestedObjectTest : Spek({
                   coll = [
                            NestedSmallObject(
                              smallObject = SmallObject(
-                               field1 = a
+                               field1 = "a"
                                field2 = 1
                              )
                            )
@@ -144,25 +144,25 @@ object NestedObjectTest : Spek({
                   coll = [
                            NestedSmallObject(
                              smallObject = SmallObject(
-                               field1 = a
+                               field1 = "a"
                                field2 = 1
                              )
                            ),
                            NestedSmallObject(
                              smallObject = SmallObject(
-                               field1 = a
+                               field1 = "a"
                                field2 = 1
                              )
                            ),
                            NestedSmallObject(
                              smallObject = SmallObject(
-                               field1 = a
+                               field1 = "a"
                                field2 = 1
                              )
                            ),
                            NestedSmallObject(
                              smallObject = SmallObject(
-                               field1 = a
+                               field1 = "a"
                                field2 = 1
                              )
                            )

--- a/src/test/kotlin/com/tylerthrailkill/helpers/prettyprint/SmallObjectTest.kt
+++ b/src/test/kotlin/com/tylerthrailkill/helpers/prettyprint/SmallObjectTest.kt
@@ -23,7 +23,7 @@ object SmallObjectTest : Spek({
             it("two fields") {
                 prettyPrint(SmallObject("a", 1)) mapsTo """
                 SmallObject(
-                  field1 = a
+                  field1 = "a"
                   field2 = 1
                 )
             """


### PR DESCRIPTION
closes #6 

this results in some weird printing in certain cases though, like 
```kotlin
EmailAddress(
  serialVersionUUID = 1
  emailAddress = ""john..doe"@example.org"
)
```

I'm choosing _not_ to escape these, because I would like the pretty printing to be as easy to parse as possible, and escape chars really get in the way of that. 