### PR TITLE
Fixed errors in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 
 Adds a `pp(Any?)` and `T.pp()` method to pretty print any Java or Kotlin object.
 
-`pp(Any?)` takes an object and prints in a pretty format.
-`T.pp()` pretty prints inside a method chain when called on an object.
+`pp(Any?)` takes any object and prints it in a pretty format.
+`T.pp()` pretty prints inside a method chain when called on an object inline.
 
 <table>
     <thead><tr><th>Approach</th><th>Instruction</th></tr></thead>
@@ -32,7 +32,7 @@ Adds a `pp(Any?)` and `T.pp()` method to pretty print any Java or Kotlin object.
 
 `tabSize` changes the number of spaces used to indent each level of the output. Default is `2`.
 
-`printStream` changes the `PrintStream` being used. Default is `System.out`.
+`printStream` changes the `PrintStream` you are printing to. Default is `System.out`.
 
 `wrappedLineWidth` changes the number of characters allowed before wrapping in a multiline string. Default is `80`.
  
@@ -212,6 +212,6 @@ O1(
 
 # ToDo
 
-* Test nullability cases,
-* implement pretty print for `java*` classes and
-* fix unicode line breaking with icu4j library characters.
+* Test nullability cases
+* implement pretty print for `java*` classes 
+* fix unicode line breaking with icu4j library characters

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
  
 # pretty-print - pp
 
-Adds a `pp(Any?)` and `T.pp()` method to pretty print Java or Kotlin object.
+Adds a `pp(Any?)` and `T.pp()` method to pretty print any Java or Kotlin object.
 
 `pp(Any?)` takes an object and prints in a pretty format.
 `T.pp()` pretty prints inside a method chain when called on an object.

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
  
 # pretty-print - pp
 
-Adds a `pp(Any?)` and `T.pp()` method to pretty print any Java or Kotlin object.
+Adds a `pp(Any?)` and `T.pp()` method to pretty print Java or Kotlin object.
 
-`pp(Any?)` takes any object and will print it in a pretty format.
-`T.pp()` can be called on any object inline and will allow you to pretty print inside of a method chain.
+`pp(Any?)` takes an object and prints in a pretty format.
+`T.pp()` pretty prints inside a method chain when called on an object.
 
 <table>
     <thead><tr><th>Approach</th><th>Instruction</th></tr></thead>
@@ -30,11 +30,11 @@ Adds a `pp(Any?)` and `T.pp()` method to pretty print any Java or Kotlin object.
 
 `pp(obj: Any?, tabSize: Int = 2, printStream: PrintStream = System.out, wrappedLineWidth: Int = 80)`
 
-`tabSize` allows you to change the number of spaces used to indent each level of the output. Default is `2`.
+`tabSize` changes the number of spaces used to indent each level of the output. Default is `2`.
 
-`printStream` allows you to change the `PrintStream` you are printing to. Default is `System.out`.
+`printStream` changes the `PrintStream` being used. Default is `System.out`.
 
-`wrappedLineWidth` allows you to change how many characters are allowed before wrapping in a multiline string. Default is `80`.
+`wrappedLineWidth` changes the number of characters allowed before wrapping in a multiline string. Default is `80`.
  
 # Examples
 ### Main API

--- a/README.md
+++ b/README.md
@@ -212,6 +212,6 @@ O1(
 
 # ToDo
 
-* test nullability cases
-* allow printing of `java*` classes
-* fix unicode line breaking with certain characters only under icu4j library
+* Test nullability cases,
+* implement pretty print for `java*` classes and
+* fix unicode line breaking with icu4j library characters.


### PR DESCRIPTION
'any', 'you are printing to' -> removed as these are redundant in context.
'allow', 'can', 'allows you to change' -> metadiscourse removed.
'test' -> Test
Fixed punctuation -> full in the end of the file was missing. A comma in line 216 added.
Sentence restructured for conciseness.
Fixes #17 