### PR TITLE
Add prettyprint support for arrays

### DIFF
--- a/src/main/kotlin/com/tylerthrailkill/helpers/prettyprint/PrettyPrint.kt
+++ b/src/main/kotlin/com/tylerthrailkill/helpers/prettyprint/PrettyPrint.kt
@@ -93,6 +93,7 @@ private class PrettyPrinter(val tabSize: Int, val writeTo: Appendable, val wrapp
             obj is String -> ppString(obj, collectionElementPad)
             obj is Enum<*> -> ppEnum(obj)
             obj.isAtomic() -> ppAtomic(obj)
+            obj is Array<*> -> ppArray(obj, collectionElementPad)
             obj is Any -> ppPlainObject(obj, objectFieldPad)
         }
         visited.remove(id)
@@ -146,6 +147,20 @@ private class PrettyPrinter(val tabSize: Int, val writeTo: Appendable, val wrapp
 
         writeLine('[')
         obj.ppContents(currentDepth, ",") {
+            write(increasedDepth)
+            ppAny(it, increasedDepth)
+        }
+        write(']')
+    }
+
+    private fun ppArray(obj: Array<*>, currentDepth: String) {
+        val increasedDepth = deepen(currentDepth)
+
+        // https://stackoverflow.com/questions/35938906/why-doesnt-kotlin-arrayt-implement-iterablet
+        val iterableList = obj.toList()
+
+        writeLine('[')
+        iterableList.ppContents(currentDepth, ",") {
             write(increasedDepth)
             ppAny(it, increasedDepth)
         }

--- a/src/test/kotlin/com/tylerthrailkill/helpers/prettyprint/CollectionsTest.kt
+++ b/src/test/kotlin/com/tylerthrailkill/helpers/prettyprint/CollectionsTest.kt
@@ -7,6 +7,25 @@ import java.io.ByteArrayOutputStream
 object CollectionsTest : Spek({
     setup()
 
+    describe("pretty printing array should") {
+        it("render an array") {
+            prettyPrint(Array(1){ 0 }) mapsTo """
+                [
+                  0
+                ]
+                """
+        }
+        it("render an array of array") {
+            prettyPrint(Array(1){Array(1) { 0 } }) mapsTo """
+                [
+                  [
+                    0
+                  ]
+                ]
+                """
+        }
+    }
+
     describe("pretty printing lists should") {
         it("render a list of strings") {
             prettyPrint(listOf("a", "b", "c")) mapsTo """


### PR DESCRIPTION
The goal of this pr is to add prettyprint support to arrays. Arrays are not implementing Iterable in java, neither in Kotlin

https://stackoverflow.com/questions/35938906/why-doesnt-kotlin-arrayt-implement-iterablet

```kotlin
val array = Array(1) { 0 }

array is Iterable<*> // false
array is Any // true
```

Before this pr
```kotlin
val array = Array(1) { 0 }
pp(array)
Integer[](
)
```